### PR TITLE
Remove placeholder images from production website

### DIFF
--- a/components/features/native-app-feature.tsx
+++ b/components/features/native-app-feature.tsx
@@ -29,9 +29,6 @@ export function NativeAppFeature({ dict }: { dict: any }) {
             </div>
           </div>
           <div className="relative">
-            <div className="relative z-10 rounded-lg shadow-xl overflow-hidden border border-gray-200 bg-gray-100 h-80 flex items-center justify-center">
-              <p className="text-gray-500">{dict.previewText}</p>
-            </div>
             <div className="absolute -bottom-6 -right-6 w-64 h-64 bg-primary/5 rounded-full z-0"></div>
             <div className="absolute -top-6 -left-6 w-32 h-32 bg-primary/5 rounded-full z-0"></div>
           </div>


### PR DESCRIPTION
## Summary
Remove placeholder images from the production website to improve professional appearance and user experience.

## Changes Made

### ✅ Native App Features Page
- **File:** `components/features/native-app-feature.tsx`
- **Change:** Removed gray placeholder box from hero section right side
- **Result:** Clean layout with decorative background circles only
- **URL:** https://www.publica.la/en/features/native-app

## Additional Placeholder Issues Identified

During the audit, I found several other placeholder elements that may need attention:

### 📁 Physical Placeholder Files (`/public`)
- `placeholder-9la75.png` (11KB)
- `placeholder-logo.png` (568 bytes) 
- `placeholder-logo.svg` (3.2KB)
- `placeholder-user.jpg` (1.6KB)
- `placeholder.jpg` (1KB)
- `placeholder.svg` (3.2KB)

### 🖼️ Code References Using Placeholders
- Customer logos showcase component with dynamic placeholders
- Case study components with hardcoded placeholder references
- Theme options component using placeholder fallbacks
- About team component with placeholder user images

## Test Plan
- [x] Build passes successfully
- [x] Native app page loads without placeholder image
- [x] Layout remains visually appealing with background circles
- [ ] Review other placeholder usage for future PRs

## Next Steps
This PR focuses on the immediate fix for the native app page. Additional placeholder cleanup can be addressed in follow-up PRs if needed.

🤖 Generated with [Claude Code](https://claude.ai/code)